### PR TITLE
Support disabling printing of events to stdout

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -4,3 +4,4 @@ catch error
   module.exports =
     SRCOMP: process.env.SRCOMP_URL or 'https://www.studentrobotics.org/comp-api'
     WEB_PORT: process.env.PORT or 5001
+    DEBUG: true

--- a/config.local.coffee.example
+++ b/config.local.coffee.example
@@ -1,3 +1,5 @@
 module.exports =
   SRCOMP: "https://www.studentrobotics.org/comp-api"
   WEB_PORT: 5001
+  # DEBUG causes all events to also be printed to stdout
+  DEBUG: true

--- a/server.coffee
+++ b/server.coffee
@@ -9,6 +9,6 @@ console.log('Using', configuration)
 comp = new srcomp.SRComp(configuration.SRCOMP)
 
 comp.events.onValue (event) ->
-  console.log JSON.stringify(event, null, 2)
+  console.log JSON.stringify(event, null, 2) if configuration.DEBUG
 
 sse(comp).listen(configuration.WEB_PORT, '::')

--- a/server.coffee
+++ b/server.coffee
@@ -8,7 +8,8 @@ console.log('Using', configuration)
 
 comp = new srcomp.SRComp(configuration.SRCOMP)
 
-comp.events.onValue (event) ->
-  console.log JSON.stringify(event, null, 2) if configuration.DEBUG
+if configuration.DEBUG
+  comp.events.onValue (event) ->
+    console.log JSON.stringify(event, null, 2)
 
 sse(comp).listen(configuration.WEB_PORT, '::')


### PR DESCRIPTION
These are useful in development, however I suspect they're related to the stability issues (https://github.com/PeterJCLaw/srcomp-stream/issues/5) we see in production.